### PR TITLE
Besu privacy groups

### DIFF
--- a/deploy-transact/README.md
+++ b/deploy-transact/README.md
@@ -39,9 +39,32 @@ node test.js --url=<url of the target node> --deploy --privateFor='["<private tr
 ```
 **Note:** the privateFor argument value must be delimited with single quotes, and use double quotes for each of the target private addresses, in order for the script to successfully parse
 
+### Besu Privacy Groups
+
+#### Create a besu privacy group
+```
+node test.js --url=<url of the target node> --privacy_groups --create  --besu_private --addresses=<private transaction addresses of privacy group members(s)>
+```
+
+#### Delete a besu privacy group
+```
+node test.js --url=<url of the target node> --privacy_groups --destroy  --besu_private --privacyGroupId=<privacy group id>
+```
+
+#### find besu privacy groups
+```
+node test.js --url=<url of the target node> --privacy_groups --find  --besu_private --addresses=<private transaction addresses of privacy group members(s)>
+```
+
+
 ### Deploy a private smart contract to a Besu node
 ```
 node test.js --url=<url of the target node> --deploy --besu_private --privateFor=<private transaction addresses of receiver(s)> --privateFrom=<private transaction address of sender>
+```
+
+Using privacy group id
+```
+node test.js --url=<url of the target node> --deploy --besu_private --privateGroupId=<privacy group id> --privateFrom=<private transaction address of sender>
 ```
 **NOTE:** List receiver addresses seperated by comma(,)
 
@@ -55,9 +78,19 @@ node test.js --url=<url of the target node> --contract=<contract address from th
 node test.js --url=<url of the target node> --contract=<contract address from the output above> --set=<new value> --besu_private --privateFor=<private transaction addresses of receiver(s)> --privateFrom=<private transaction address of sender>
 ```
 
+Using privacy group id
+```
+node test.js --url=<url of the target node> --contract=<contract address from the output above> --set=<new value> --besu_private --privateGroupId=<privacy group id> --privateFrom=<private transaction address of sender>
+```
+
 ### Query a private transaction from a Besu node
 ```
 node test.js --url=<url of the target node> --contract=<contract address from the output above> --query --besu_private --privateFor=<private transaction addresses of receiver(s)> --privateFrom=<private transaction address of sender>
+```
+
+Using privacy group id
+```
+node test.js --url=<url of the target node> --contract=<contract address from the output above> --query --besu_private --privateGroupId=<privacy group id> --privateFrom=<private transaction address of sender>
 ```
 
 ### Use an external account to deploy contract and sign a transaction

--- a/deploy-transact/README.md
+++ b/deploy-transact/README.md
@@ -64,7 +64,7 @@ node test.js --url=<url of the target node> --deploy --besu_private --privateFor
 
 Using privacy group id
 ```
-node test.js --url=<url of the target node> --deploy --besu_private --privateGroupId=<privacy group id> --privateFrom=<private transaction address of sender>
+node test.js --url=<url of the target node> --deploy --besu_private --privateGroupId=<privacy group id> --privateFrom=<private transaction address of sender> --chainId=<chain id of environment>
 ```
 **NOTE:** List receiver addresses seperated by comma(,)
 
@@ -80,7 +80,7 @@ node test.js --url=<url of the target node> --contract=<contract address from th
 
 Using privacy group id
 ```
-node test.js --url=<url of the target node> --contract=<contract address from the output above> --set=<new value> --besu_private --privateGroupId=<privacy group id> --privateFrom=<private transaction address of sender>
+node test.js --url=<url of the target node> --contract=<contract address from the output above> --set=<new value> --besu_private --privateGroupId=<privacy group id> --privateFrom=<private transaction address of sender> --chainId=<chain id of environment>
 ```
 
 ### Query a private transaction from a Besu node

--- a/deploy-transact/test.js
+++ b/deploy-transact/test.js
@@ -19,12 +19,19 @@ const privateFrom = argv.privateFrom;
 const externallySign = argv.sign;
 const azure = argv.azure;
 const besu_private = argv.besu_private;
+const privacy_groups = argv.privacy_groups;
+const find = argv.find;
+const create = argv.create;
+const destroy = argv.destroy;
 
+const addresses = argv.addresses;
+// besu privacy group
+const privacyGroupId = argv.privacyGroupId;
 let contractName = 'simplestorage';
 
 if (query) {
   if (besu_private) {
-    getSigner().queryTransaction(contractAddress, privateFor, privateFrom);
+    getSigner().queryTransaction(contractAddress, privateFor, privateFrom, privacyGroupId);
 
   } else {
     // must also pass in the contract address
@@ -52,11 +59,26 @@ if (query) {
     }
 
     let newValue = set;
-    getSigner().sendTransaction(contractAddress, newValue, privateFor, privateFrom);
+    if(besu_private) {
+      getSigner().sendTransaction(contractAddress, newValue, privateFor, privateFrom, privacyGroupId);
+    } else {
+      getSigner().sendTransaction(contractAddress, newValue, privateFor, privateFrom);
+    }
     listen();
 
 } else if (deploy) {
-    getSigner().deployContract(privateFor,privateFrom);
+    if(besu_private) {
+      getSigner().deployContract(privateFor,privateFrom,privacyGroupId);
+    } else {
+      getSigner().deployContract(privateFor,privateFrom);
+    }
+} else if(besu_private && privacy_groups) {
+  if(find)
+    getSigner().getPrivacyGroups(addresses);
+  if(create)
+    getSigner().createPrivacyGroup(addresses);
+  if(destroy)
+    getSigner().deletePrivacyGroup(privacyGroupId);
 }
 
 function getSigner() {


### PR DESCRIPTION
Added support to `create/delete/find` `besu` privacy groups.

Also added options to specify `privacyGroupId` instead of `privateFor` for besu private transactions.